### PR TITLE
recommended extensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@
 
 !.vscode
 !.vscode/settings.json
+!.vscode/extensions.json

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+    "recommendations": [
+        "yzhang.markdown-all-in-one",
+        "davidanson.vscode-markdownlint"
+    ]
+}


### PR DESCRIPTION
Ich dachte ich füg mal markdown-all-in-one und markdownlint als recommend vscode extensions dem repo hinzu.