### PR TITLE
Rename NET-Barie heading

### DIFF
--- a/NET-BARIE/README.md
+++ b/NET-BARIE/README.md
@@ -15,7 +15,7 @@ header-includes:
 
 ---------->
 
-Rechnernetzadministration/Verteilte Systeme
+Rechnernetzadministration
 ===========================================
 
 <!-- md2apkg ignore-card -->


### PR DESCRIPTION
Verteilte Systeme kamen im 5. Semester nicht, das kommt im 6. 
Gleichzeitig löst das auch #57